### PR TITLE
Fix test datasets

### DIFF
--- a/mokapot/dataset.py
+++ b/mokapot/dataset.py
@@ -456,7 +456,9 @@ class LinearPsmDataset(PsmDataset):
         return self.data.loc[:, self._peptide_column]
 
     def _update_labels(self, scores, eval_fdr=0.01, desc=True):
-        return _update_labels(scores=scores, targets=self.targets, desc=desc)
+        return _update_labels(
+            scores=scores, targets=self.targets, eval_fdr=eval_fdr, desc=desc
+        )
 
 
 class CrossLinkedPsmDataset(PsmDataset):

--- a/tests/unit_tests/test_dataset.py
+++ b/tests/unit_tests/test_dataset.py
@@ -41,52 +41,6 @@ def test_linear_init(psm_df_6):
     assert not dset.has_proteins
 
 
-def test_assign_confidence(psm_df_1000):
-    """Test that assign_confidence() methods run"""
-    psms, fasta = psm_df_1000
-    dset = LinearPsmDataset(
-        psms=psms,
-        target_column="target",
-        spectrum_columns="spectrum",
-        peptide_column="peptide",
-        feature_columns="score",
-        copy_data=True,
-    )
-
-    # also try adding proteins:
-    assert not dset.has_proteins
-    dset.add_proteins(fasta, missed_cleavages=0, min_length=5, max_length=5)
-    assert dset.has_proteins
-
-    dset.assign_confidence(eval_fdr=0.05)
-
-    # Make sure it works when lower scores are better:
-    data, _ = psm_df_1000
-    data["score"] = -data["score"]
-    dset = LinearPsmDataset(
-        psms=data,
-        target_column="target",
-        spectrum_columns="spectrum",
-        peptide_column="peptide",
-        feature_columns="score",
-        copy_data=True,
-    )
-    dset.assign_confidence(eval_fdr=0.05)
-
-    # Verify that the groups yields 2 results:
-    dset = LinearPsmDataset(
-        psms=psms,
-        target_column="target",
-        spectrum_columns="spectrum",
-        peptide_column="peptide",
-        group_column="group",
-        feature_columns="score",
-        copy_data=True,
-    )
-    res = dset.assign_confidence(eval_fdr=0.05)
-    assert len(res) == 2
-
-
 def test_update_labels(psm_df_6):
     """Test that the _update_labels() methods are working"""
     dset = LinearPsmDataset(


### PR DESCRIPTION
- Remove assign confidence tests because datasets don't have assign confidence methods anymore
- Add eval_fdr value to the _update_labels function
closes  #15 