### PR TITLE
Fix test confidence

### DIFF
--- a/mokapot/__init__.py
+++ b/mokapot/__init__.py
@@ -22,4 +22,4 @@ from .parsers.pin import read_pin, read_percolator
 from .parsers.pepxml import read_pepxml
 from .parsers.fasta import read_fasta, make_decoys, digest
 from .writers import to_flashlfq, to_txt
-from .confidence import LinearConfidence, plot_qvalues
+from .confidence import LinearConfidence, plot_qvalues, assign_confidence

--- a/mokapot/dataset.py
+++ b/mokapot/dataset.py
@@ -662,7 +662,7 @@ class OnDiskPsmDataset:
 
         return (
             _update_labels(
-                df.loc[:, self.columns],
+                df.loc[:, column],
                 targets=df.loc[:, self.target_column],
                 eval_fdr=eval_fdr,
                 desc=desc,

--- a/mokapot/dataset.py
+++ b/mokapot/dataset.py
@@ -456,7 +456,9 @@ class LinearPsmDataset(PsmDataset):
         return self.data.loc[:, self._peptide_column]
 
     def _update_labels(self, scores, eval_fdr=0.01, desc=True):
-        return _update_labels(scores=scores, targets=self.targets, desc=desc)
+        return _update_labels(
+            scores=scores, targets=self.targets, eval_fdr=eval_fdr, desc=desc
+        )
 
 
 class CrossLinkedPsmDataset(PsmDataset):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,33 +23,77 @@ def psm_df_6():
 
 
 @pytest.fixture()
+def psm_df_100(tmp_path):
+    """A DataFrame with 100 PSMs."""
+    rng = np.random.Generator(np.random.PCG64(42))
+    targets = {
+        "specid": np.arange(50),
+        "target": [True] * 50,
+        "scannr": np.random.randint(0, 100, 50),
+        "calcmass": rng.uniform(500, 2000, size=50),
+        "expmass": rng.uniform(500, 2000, size=50),
+        "group": rng.choice(2, size=50),
+        "peptide": [_random_peptide(5, rng) for _ in range(50)],
+        "proteins": ["_dummy" for _ in range(50)],
+        "score": np.concatenate([rng.normal(3, size=20), rng.normal(size=30)]),
+        "filename": "test.mzML",
+        "ret_time": rng.uniform(0, 60 * 120, size=50),
+        "charge": rng.choice([2, 3, 4], size=50),
+    }
+
+    decoys = {
+        "specid": np.arange(50, 100),
+        "target": [False] * 50,
+        "scannr": np.random.randint(0, 100, 50),
+        "calcmass": rng.uniform(500, 2000, size=50),
+        "expmass": rng.uniform(500, 2000, size=50),
+        "group": rng.choice(2, size=50),
+        "peptide": [_random_peptide(5, rng) for _ in range(50)],
+        "proteins": ["_dummy" for _ in range(50)],
+        "score": rng.normal(size=50),
+        "filename": "test.mzML",
+        "ret_time": rng.uniform(0, 60 * 120, size=50),
+        "charge": rng.choice([2, 3, 4], size=50),
+    }
+
+    pin = tmp_path / "test.pin"
+    df = pd.concat([pd.DataFrame(targets), pd.DataFrame(decoys)])
+    df.to_csv(pin, sep="\t", index=False)
+    return pin
+
+
+@pytest.fixture()
 def psm_df_1000(tmp_path):
     """A DataFrame with 1000 PSMs from 500 spectra and a FASTA file."""
     rng = np.random.Generator(np.random.PCG64(42))
     targets = {
+        "specid": np.arange(500),
         "target": [True] * 500,
-        "spectrum": np.arange(500),
-        "group": rng.choice(2, size=500),
+        "scannr": np.random.randint(0, 1000, 500),
+        "calcmass": rng.uniform(500, 2000, size=500),
+        "expmass": rng.uniform(500, 2000, size=500),
+        "group": [0 for _ in range(500)],
         "peptide": [_random_peptide(5, rng) for _ in range(500)],
+        "proteins": ["_dummy" for _ in range(500)],
         "score": np.concatenate(
             [rng.normal(3, size=200), rng.normal(size=300)]
         ),
         "filename": "test.mzML",
-        "calcmass": rng.uniform(500, 2000, size=500),
-        "expmass": rng.uniform(500, 2000, size=500),
         "ret_time": rng.uniform(0, 60 * 120, size=500),
         "charge": rng.choice([2, 3, 4], size=500),
     }
 
     decoys = {
+        "specid": np.arange(500, 1000),
         "target": [False] * 500,
-        "spectrum": np.arange(500),
-        "group": rng.choice(2, size=500),
-        "peptide": [_random_peptide(5, rng) for _ in range(500)],
-        "score": rng.normal(size=500),
-        "filename": "test.mzML",
+        "scannr": np.random.randint(0, 1000, 500),
         "calcmass": rng.uniform(500, 2000, size=500),
         "expmass": rng.uniform(500, 2000, size=500),
+        "group": [0 for _ in range(500)],
+        "peptide": [_random_peptide(5, rng) for _ in range(500)],
+        "proteins": ["_dummy" for _ in range(500)],
+        "score": rng.normal(size=500),
+        "filename": "test.mzML",
         "ret_time": rng.uniform(0, 60 * 120, size=500),
         "charge": rng.choice([2, 3, 4], size=500),
     }
@@ -60,10 +104,12 @@ def psm_df_1000(tmp_path):
     )
 
     fasta = tmp_path / "test_1000.fasta"
+    pin = tmp_path / "test.pin"
     with open(fasta, "w+") as fasta_ref:
         fasta_ref.write(fasta_data)
-
-    return (pd.concat([pd.DataFrame(targets), pd.DataFrame(decoys)]), fasta)
+    df = pd.concat([pd.DataFrame(targets), pd.DataFrame(decoys)])
+    df.to_csv(pin, sep="\t", index=False)
+    return pin, fasta
 
 
 @pytest.fixture
@@ -126,7 +172,13 @@ def psms_ondisk():
             "dM",
             "absdM",
         ],
-        metadata_columns=["SpecId", "ScanNr", "Peptide", "Proteins", "Label"],
+        metadata_columns=[
+            "SpecId",
+            "ScanNr",
+            "Peptide",
+            "Proteins",
+            "Label",
+        ],
         filename_column=None,
         specId_column="SpecId",
         spectra_dataframe=df_spectra,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,13 +109,13 @@ def psm_df_1000(tmp_path):
         fasta_ref.write(fasta_data)
     df = pd.concat([pd.DataFrame(targets), pd.DataFrame(decoys)])
     df.to_csv(pin, sep="\t", index=False)
-    return pin, fasta
+    return pin, df, fasta
 
 
 @pytest.fixture
 def psms(psm_df_1000):
     """A small LinearPsmDataset"""
-    df, _ = psm_df_1000
+    _, df, _ = psm_df_1000
     psms = LinearPsmDataset(
         psms=df,
         target_column="target",

--- a/tests/unit_tests/test_confidence.py
+++ b/tests/unit_tests/test_confidence.py
@@ -9,7 +9,7 @@ from mokapot import OnDiskPsmDataset, assign_confidence
 def test_one_group(psm_df_1000, tmp_path):
     """Test that one group is equivalent to no group."""
 
-    pin_file, _ = psm_df_1000
+    pin_file, _, _ = psm_df_1000
     columns = list(pd.read_csv(pin_file, sep="\t").columns)
     df_spectra = pd.read_csv(
         pin_file, sep="\t", usecols=["scannr", "expmass", "target"]

--- a/tests/unit_tests/test_confidence.py
+++ b/tests/unit_tests/test_confidence.py
@@ -1,68 +1,101 @@
 """Test that Confidence classes are working correctly"""
-import pickle
-
+from pathlib import Path
 import numpy as np
 import pandas as pd
-from mokapot import LinearPsmDataset
+import copy
+from mokapot import OnDiskPsmDataset, assign_confidence
 
 
-def test_one_group(psm_df_1000):
+def test_one_group(psm_df_1000, tmp_path):
     """Test that one group is equivalent to no group."""
-    psm_data, _ = psm_df_1000
-    psm_data["group"] = 0
 
-    psms = LinearPsmDataset(
-        psms=psm_data,
+    pin_file, _ = psm_df_1000
+    columns = list(pd.read_csv(pin_file, sep="\t").columns)
+    df_spectra = pd.read_csv(
+        pin_file, sep="\t", usecols=["scannr", "expmass", "target"]
+    )
+    psms_disk = OnDiskPsmDataset(
+        filename=pin_file,
         target_column="target",
-        spectrum_columns="spectrum",
+        spectrum_columns=["scannr", "expmass"],
         peptide_column="peptide",
-        feature_columns="score",
+        feature_columns=["score"],
         filename_column="filename",
-        scan_column="spectrum",
+        scan_column="scannr",
         calcmass_column="calcmass",
         expmass_column="expmass",
         rt_column="ret_time",
         charge_column="charge",
+        columns=columns,
+        protein_column=None,
         group_column="group",
-        copy_data=True,
+        metadata_columns=[
+            "specid",
+            "scannr",
+            "expmass",
+            "peptide",
+            "proteins",
+            "target",
+        ],
+        specId_column="spectrum",
+        spectra_dataframe=df_spectra,
     )
+    np.random.seed(42)
+    assign_confidence(
+        [copy.copy(psms_disk)],
+        prefixes=[None],
+        descs=[True],
+        dest_dir=tmp_path,
+    )
+    df_results_group = pd.read_csv(tmp_path / "0.targets.peptides", sep="\t")
 
     np.random.seed(42)
-    grouped = psms.assign_confidence()
-    scores1 = grouped.group_confidence_estimates[0].psms["mokapot score"]
+    psms_disk.group_column = None
+    assign_confidence(
+        [psms_disk], prefixes=[None], descs=[True], dest_dir=tmp_path
+    )
+    df_results_no_group = pd.read_csv(tmp_path / "targets.peptides", sep="\t")
 
-    np.random.seed(42)
-    psms._group_column = None
-    ungrouped = psms.assign_confidence()
-    scores2 = ungrouped.psms["mokapot score"]
-
-    pd.testing.assert_series_equal(scores1, scores2)
+    pd.testing.assert_frame_equal(df_results_group, df_results_no_group)
 
 
-def test_pickle(psm_df_1000, tmp_path):
-    """Test that pickling works"""
-    psm_data, _ = psm_df_1000
-    psm_data["group"] = 0
-
-    psms = LinearPsmDataset(
-        psms=psm_data,
+def test_multi_groups(psm_df_100, tmp_path):
+    """Test that group results are saved"""
+    pin_file = psm_df_100
+    columns = list(pd.read_csv(pin_file, sep="\t").columns)
+    df_spectra = pd.read_csv(
+        pin_file, sep="\t", usecols=["scannr", "expmass", "target"]
+    )
+    psms_disk = OnDiskPsmDataset(
+        filename=pin_file,
         target_column="target",
-        spectrum_columns="spectrum",
+        spectrum_columns=["scannr", "expmass"],
         peptide_column="peptide",
-        feature_columns="score",
+        feature_columns=["score"],
         filename_column="filename",
-        scan_column="spectrum",
+        scan_column="scannr",
         calcmass_column="calcmass",
         expmass_column="expmass",
         rt_column="ret_time",
         charge_column="charge",
-        copy_data=True,
+        columns=columns,
+        protein_column=None,
+        group_column="group",
+        metadata_columns=[
+            "specid",
+            "scannr",
+            "expmass",
+            "peptide",
+            "proteins",
+            "target",
+        ],
+        specId_column="spectrum",
+        spectra_dataframe=df_spectra,
     )
-
-    results = psms.assign_confidence()
-    pkl_file = tmp_path / "results.pkl"
-    with pkl_file.open("wb+") as pkl_dat:
-        pickle.dump(results, pkl_dat)
-
-    with pkl_file.open("rb") as pkl_dat:
-        pickle.load(pkl_dat)
+    assign_confidence(
+        [psms_disk], prefixes=[None], descs=[True], dest_dir=tmp_path
+    )
+    assert Path(tmp_path, f"{0}.targets.psms").exists()
+    assert Path(tmp_path, f"{1}.targets.psms").exists()
+    assert Path(tmp_path, f"{0}.targets.peptides").exists()
+    assert Path(tmp_path, f"{1}.targets.peptides").exists()


### PR DESCRIPTION
- fix bugs for grouped confidence
- fix test_one_group : create file using psm_df_1000 to create OnDiskPsmDataset.
- remove test_pickle because confidence does not return dataframe results anymore.
- add test_multi_groups to test that different group results are saved correctly.
closes #21 