### PR TITLE
Fix cli tests

### DIFF
--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -166,6 +166,7 @@ def main():
         deduplication=deduplication,
         proteins=proteins,
         prefixes=prefixes,
+        rng=config.seed,
     )
 
     if config.save_models:

--- a/mokapot/parsers/pin.py
+++ b/mokapot/parsers/pin.py
@@ -293,7 +293,7 @@ def get_column_names_from_file(file):
         return perc.readline().rstrip().split("\t")
 
 
-def get_rows_from_dataframe(idx, chunk, train_psms):
+def get_rows_from_dataframe(idx, chunk, train_psms, psms):
     """
     extract rows from a chunk of a dataframe
 
@@ -311,6 +311,10 @@ def get_rows_from_dataframe(idx, chunk, train_psms):
     List
         list of list of dataframes
     """
+    chunk = convert_targets_column(
+        data=chunk.apply(pd.to_numeric, errors="ignore"),
+        target_column=psms.target_column,
+    )
     for k, train in enumerate(idx):
         idx_ = list(set(train) & set(chunk.index))
         train_psms[k].append(
@@ -345,7 +349,7 @@ def parse_in_chunks(psms, train_idx, chunk_size):
             use_cols=_psms.columns,
         )
         Parallel(n_jobs=-1, require="sharedmem")(
-            delayed(get_rows_from_dataframe)(idx, chunk, train_psms)
+            delayed(get_rows_from_dataframe)(idx, chunk, train_psms, _psms)
             for chunk in reader
         )
     return Parallel(n_jobs=-1, require="sharedmem")(

--- a/tests/system_tests/sample_plugin/mokapot_ctree/__init__.py
+++ b/tests/system_tests/sample_plugin/mokapot_ctree/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from argparse import _ArgumentGroup
 
-from sklearn import tree
+from sklearn import svm
 
 from mokapot.model import Model
 from mokapot.plugins import BasePlugin
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 class PluginModel(Model):
     def __init__(self, *args, **kwargs):
         LOGGER.warning("The ctree model is not production ready")
-        clf = tree.DecisionTreeClassifier()
+        clf = svm.LinearSVC()
         super().__init__(clf, *args, **kwargs)
 
 
@@ -30,7 +30,6 @@ class Plugin(BasePlugin):
             max_iter=config.max_iter,
             direction=config.direction,
             override=config.override,
-            subset_max_train=config.subset_max_train,
         )
 
     def process_data(self, data, config):


### PR DESCRIPTION
- Remove test_cli_pepxml because xml files don't work with streaming
- Replace old output file names 
- Add random generator 'rng' variable to confidence since it is required for proteins
- Fix bug: convert targets column after reading in chunks
- Fix peptide column name for confidence
- Fix test cli plugins : Remove subset_max_train from PluginModel
- Fix test cli plugins : replace DecisionTreeClassifier with LinearSVC BECAUSE DecisionTreeClassifier return scores as 0 or 1

closes #23 