### PR TITLE
Fix writer tests

### DIFF
--- a/tests/unit_tests/test_writer_flashlfq.py
+++ b/tests/unit_tests/test_writer_flashlfq.py
@@ -6,21 +6,6 @@ import numpy as np
 import pandas as pd
 
 
-def test_sanity(psms, tmp_path):
-    """Run simple sanity checks"""
-    conf = psms.assign_confidence()
-    test1 = conf.to_flashlfq(tmp_path / "test1.txt")
-    mokapot.to_flashlfq(conf, tmp_path / "test2.txt")
-    test3 = mokapot.to_flashlfq([conf, conf], tmp_path / "test3.txt")
-    with pytest.raises(ValueError):
-        mokapot.to_flashlfq("blah", tmp_path / "test4.txt")
-
-    df1 = pd.read_table(test1)
-    df3 = pd.read_table(test3)
-    assert 2 * len(df1) == len(df3)
-    assert len(df1.columns) == 7
-
-
 def test_basic(mock_conf, tmp_path):
     """Test that the basic output works"""
     conf = mock_conf

--- a/tests/unit_tests/test_writer_txt.py
+++ b/tests/unit_tests/test_writer_txt.py
@@ -1,30 +1,7 @@
 """Check that writing tab-delimited files works well"""
-from pathlib import Path
 
-import pytest
 import mokapot
 import pandas as pd
-
-
-def test_sanity(psms, tmp_path):
-    """Run simple sanity checks"""
-    conf = psms.assign_confidence()
-    test1 = conf.to_txt(dest_dir=tmp_path, file_root="test1")
-    mokapot.to_txt(conf, dest_dir=tmp_path, file_root="test2")
-    test3 = mokapot.to_txt([conf, conf], dest_dir=tmp_path, file_root="test3")
-    with pytest.raises(ValueError):
-        mokapot.to_txt("blah", dest_dir=tmp_path)
-
-    test4 = mokapot.to_txt(conf, dest_dir=tmp_path, decoys=True)
-    assert len(test1) == 2
-    assert len(test4) == 4
-
-    fnames = [Path(f).name for f in test1]
-    assert fnames == ["test1.mokapot.psms.txt", "test1.mokapot.peptides.txt"]
-
-    df1 = pd.read_table(test1[0])
-    df3 = pd.read_table(test3[1])
-    assert 2 * len(df1) == len(df3)
 
 
 def test_columns(mock_conf, tmp_path):


### PR DESCRIPTION
- Remove writer tests with confidence object becaause LinearPsmDataset does not have asign_confidence method anymore and results are streamed to output files while computing confidence

closes #27 #26 