### PR TITLE
fix error no psms found during training

### DIFF
--- a/mokapot/model.py
+++ b/mokapot/model.py
@@ -316,6 +316,9 @@ class Model:
                 "\t- Iteration %i: %i training PSMs passed.", i, num_passed[i]
             )
 
+            if num_passed[i] == 0:
+                raise RuntimeError("Model performs worse after training.")
+
         # If the model performs worse than what was initialized:
         if (
             num_passed[-1] < (start_labels == 1).sum()


### PR DESCRIPTION
 if no psms passed the fdr value then raise error that model performed worse