### PR TITLE
Fix/help and config

### DIFF
--- a/mokapot/config.py
+++ b/mokapot/config.py
@@ -15,37 +15,20 @@ class MokapotHelpFormatter(argparse.HelpFormatter):
 
     def _fill_text(self, text, width, indent):
         text_list = text.splitlines(keepends=True)
-        return "\n".join(
-            _process_line(line, width, indent) for line in text_list
-        )
+        return "\n".join(_process_line(line, width, indent) for line in text_list)
 
 
-class Config:
+class Config(argparse.Namespace):
     """
     The mokapot configuration options.
 
     Options can be specified as command-line arguments.
     """
 
-    def __init__(self, parser=None, main_args=None) -> None:
+    def __init__(self, args=None) -> None:
         """Initialize configuration values."""
-        self._namespace = None
-        if parser is None:
-            self.parser = _parser()
-        else:
-            self.parser = parser
-        self.main_args = main_args
-
-    @property
-    def args(self):
-        """Collect args lazily."""
-        if self._namespace is None:
-            self._namespace = vars(self.parser.parse_args(self.main_args))
-
-        return self._namespace
-
-    def __getattr__(self, option):
-        return self.args[option]
+        parser = _parser()
+        parser.parse_args(args, namespace=self)
 
 
 def _parser():
@@ -66,10 +49,7 @@ def _parser():
         "psm_files",
         type=Path,
         nargs="+",
-        help=(
-            "A collection of PSMs in the Percolator tab-delimited or PepXML "
-            "format."
-        ),
+        help=("A collection of PSMs in the Percolator tab-delimited or PepXML format."),
     )
 
     parser.add_argument(
@@ -151,10 +131,7 @@ def _parser():
         "--clip_nterm_methionine",
         default=False,
         action="store_true",
-        help=(
-            "Remove methionine residues that occur"
-            " at the protein N-terminus.",
-        ),
+        help=("Remove methionine residues that occur at the protein N-terminus."),
     )
 
     parser.add_argument(
@@ -259,10 +236,7 @@ def _parser():
         "--override",
         default=False,
         action="store_true",
-        help=(
-            "Use the learned model even if it performs worse "
-            "than the best feature."
-        ),
+        help=("Use the learned model even if it performs worse than the best feature."),
     )
 
     parser.add_argument(

--- a/mokapot/config.py
+++ b/mokapot/config.py
@@ -18,20 +18,7 @@ class MokapotHelpFormatter(argparse.HelpFormatter):
         return "\n".join(_process_line(line, width, indent) for line in text_list)
 
 
-class Config(argparse.Namespace):
-    """
-    The mokapot configuration options.
-
-    Options can be specified as command-line arguments.
-    """
-
-    def __init__(self, args=None) -> None:
-        """Initialize configuration values."""
-        parser = _parser()
-        parser.parse_args(args, namespace=self)
-
-
-def _parser():
+def create_config_parser():
     """The parser"""
     desc = (
         f"mokapot version {__version__}.\n"

--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -15,7 +15,7 @@ from . import __version__
 from .brew import brew
 from .confidence import assign_confidence
 from .config import Config
-from .model import PercolatorModel, load_model
+from .model import load_model, PercolatorModel
 from .parsers.fasta import read_fasta
 from .parsers.pin import read_pin
 
@@ -25,8 +25,7 @@ def main(main_args=None):
     start = time.time()
 
     # Get command line arguments
-    parser = Config().parser
-    config = Config(parser, main_args=main_args)
+    config = Config(args=main_args)
 
     # Setup logging
     verbosity_dict = {
@@ -42,7 +41,7 @@ def main(main_args=None):
         level=verbosity_dict[config.verbosity],
     )
     logging.captureWarnings(True)
-    numba_logger = logging.getLogger('numba')
+    numba_logger = logging.getLogger("numba")
     numba_logger.setLevel(logging.WARNING)
 
     # Suppress warning if asked for
@@ -52,9 +51,7 @@ def main(main_args=None):
     # Write header
     logging.info("mokapot version %s", str(__version__))
     logging.info("Written by William E. Fondrie (wfondrie@uw.edu) in the")
-    logging.info(
-        "Department of Genome Sciences at the University of Washington."
-    )
+    logging.info("Department of Genome Sciences at the University of Washington.")
 
     # Check config parameter validity
     if config.stream_confidence and config.peps_algorithm != "hist_nnls":

--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -14,7 +14,7 @@ import numpy as np
 from . import __version__
 from .brew import brew
 from .confidence import assign_confidence
-from .config import Config
+from .config import create_config_parser
 from .model import load_model, PercolatorModel
 from .parsers.fasta import read_fasta
 from .parsers.pin import read_pin
@@ -25,7 +25,8 @@ def main(main_args=None):
     start = time.time()
 
     # Get command line arguments
-    config = Config(args=main_args)
+    parser = create_config_parser()
+    config = parser.parse_args(args=main_args)
 
     # Setup logging
     verbosity_dict = {

--- a/tests/system_tests/test_cli.py
+++ b/tests/system_tests/test_cli.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 from ..helpers.cli import run_mokapot_cli
-from ..helpers.utils import file_approx_len, file_missing, file_exist
+from ..helpers.utils import file_approx_len, file_exist, file_missing
 
 
 @pytest.fixture
@@ -75,23 +75,15 @@ def test_cli_options(tmp_path, scope_files):
     filebase = ["blah." + f.name.split(".")[0] for f in scope_files[0:2]]
 
     assert file_approx_len(tmp_path, f"{filebase[0]}.targets.psms.csv", 5490)
-    assert file_approx_len(
-        tmp_path, f"{filebase[0]}.targets.peptides.csv", 5194
-    )
+    assert file_approx_len(tmp_path, f"{filebase[0]}.targets.peptides.csv", 5194)
     assert file_approx_len(tmp_path, f"{filebase[1]}.targets.psms.csv", 4659)
-    assert file_approx_len(
-        tmp_path, f"{filebase[1]}.targets.peptides.csv", 4406
-    )
+    assert file_approx_len(tmp_path, f"{filebase[1]}.targets.peptides.csv", 4406)
 
     # Test keep_decoys:
     assert file_approx_len(tmp_path, f"{filebase[0]}.decoys.psms.csv", 2090)
-    assert file_approx_len(
-        tmp_path, f"{filebase[0]}.decoys.peptides.csv", 2037
-    )
+    assert file_approx_len(tmp_path, f"{filebase[0]}.decoys.peptides.csv", 2037)
     assert file_approx_len(tmp_path, f"{filebase[1]}.decoys.psms.csv", 1806)
-    assert file_approx_len(
-        tmp_path, f"{filebase[1]}.decoys.peptides.csv", 1755
-    )
+    assert file_approx_len(tmp_path, f"{filebase[1]}.decoys.peptides.csv", 1755)
 
 
 def test_cli_aggregate(tmp_path, scope_files):
@@ -292,3 +284,19 @@ def test_negative_features(tmp_path, psm_df_1000):
     assert mean_scores("test2")[2]
     assert mean_scores("test1b")[2]
     assert mean_scores("test2b")[2]  # This one is the most likely to fail
+
+
+def test_cli_help():
+    """Test that help works"""
+
+    # Triggering help should raise a SystemExit
+    with pytest.raises(SystemExit):
+        run_mokapot_cli(["-h"], run_in_subprocess=False)
+
+    # This is caught, when run in a subprocess, and we can verify
+    # stdout (only some contents to make sure it makes sense)
+    res = run_mokapot_cli(["--help"], run_in_subprocess=True, capture_output=True)
+    stdout = res["stdout"]
+    assert "usage: mokapot" in stdout
+    assert "Written by" in stdout
+    assert "--enzyme" in stdout


### PR DESCRIPTION
Fixes a bug when invoking mokapot with '--help' and greatly simplifies the unnecessary complicated Config class.

Replaces #54 (but without the commit that didn't belong there)
