### PR TITLE
Add real typechecking for numpy arrays

### DIFF
--- a/mokapot/dataset.py
+++ b/mokapot/dataset.py
@@ -26,8 +26,7 @@ import numpy as np
 import pandas as pd
 from typeguard import typechecked
 
-from mokapot import qvalues
-from mokapot import utils
+from mokapot import qvalues, utils
 from mokapot.parsers.fasta import read_fasta
 from mokapot.proteins import Proteins
 from .tabular_data import TabularDataReader
@@ -691,7 +690,7 @@ class OnDiskPsmDataset(PsmDataset):
 
 @typechecked
 def _update_labels(
-    scores: np.ndarray[float] | pd.Series,
+    scores: np.ndarray[float | int] | pd.Series,
     targets: np.ndarray[bool] | pd.Series,
     eval_fdr: float = 0.01,
     desc: bool = True,

--- a/mokapot/mokapot.py
+++ b/mokapot/mokapot.py
@@ -18,11 +18,13 @@ from .config import create_config_parser
 from .model import load_model, PercolatorModel
 from .parsers.fasta import read_fasta
 from .parsers.pin import read_pin
+from .typecheck import register_numpy_typechecker
 
 
 def main(main_args=None):
     """The CLI entry point"""
     start = time.time()
+    register_numpy_typechecker()
 
     # Get command line arguments
     parser = create_config_parser()

--- a/mokapot/peps.py
+++ b/mokapot/peps.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TypeVar, Callable, Iterator
+from typing import Callable, Iterator, TypeVar
 
 import numpy as np
 import scipy.stats as stats
@@ -225,8 +225,8 @@ def monotonize(
 
 @typechecked
 def monotonize_nnls(
-    x: np.ndarray[float],
-    w: np.ndarray[float] | None = None,
+    x: np.ndarray[np.floating],
+    w: np.ndarray[np.floating | np.integer] | None = None,
     ascending: bool = True,
 ) -> np.ndarray[float]:
     """Monotonizes a given array `x` using non-negative least squares (NNLS)

--- a/mokapot/qvalues.py
+++ b/mokapot/qvalues.py
@@ -1,16 +1,18 @@
 """
 This module estimates q-values.
 """
-import numpy as np
-import numba as nb
-from typeguard import typechecked
+
 from typing import Callable
 
+import numba as nb
+import numpy as np
+from typeguard import typechecked
+
 from mokapot.peps import (
-    peps_from_scores_hist_nnls,
-    monotonize_simple,
-    hist_data_from_scores,
     estimate_pi0_by_slope,
+    hist_data_from_scores,
+    monotonize_simple,
+    peps_from_scores_hist_nnls,
     TDHistData,
 )
 
@@ -27,7 +29,9 @@ QVALUE_ALGORITHM = {
 
 @typechecked
 def tdc(
-    scores: np.ndarray[float], target: np.ndarray[bool], desc: bool = True
+    scores: np.ndarray[np.floating | np.integer],
+    target: np.ndarray[bool | np.floating | np.integer],
+    desc: bool = True,
 ):
     """Estimate q-values using target decoy competition.
 
@@ -70,6 +74,10 @@ def tdc(
         A 1D array with the estimated q-value for each entry. The
         array is the same length as the `scores` and `target` arrays.
     """
+    # todo: I think the allowed data types are way to general and lenient. scores
+    # should me maximally integer|floating (but better just float) and targets
+    # should only be bool, nothing else. The rest is the job of the calling code.
+
     scores = np.array(scores)
     target = np.array(target)
 
@@ -220,8 +228,7 @@ def qvalues_from_scores(
         return qvalue_function(scores, targets)
     else:
         raise ValueError(
-            "Unknown qvalue algorithm in qvalues_from_scores:"
-            f" {qvalue_algorithm}"
+            "Unknown qvalue algorithm in qvalues_from_scores:" f" {qvalue_algorithm}"
         )
 
 
@@ -280,18 +287,12 @@ def qvalues_from_peps(
 
     target_scores = scores_sorted[targets_sorted]
     target_peps = peps_sorted[targets_sorted]
-    target_fdr = target_peps.cumsum() / np.arange(
-        1, len(target_peps) + 1, dtype=float
-    )
-    target_qvalues = monotonize_simple(
-        target_fdr, ascending=True, reverse=True
-    )
+    target_fdr = target_peps.cumsum() / np.arange(1, len(target_peps) + 1, dtype=float)
+    target_qvalues = monotonize_simple(target_fdr, ascending=True, reverse=True)
 
     # Note: we need to flip the arrays again, since interp needs scores in
     #   ascending order
-    qvalues = np.interp(
-        scores, np.flip(target_scores), np.flip(target_qvalues)
-    )
+    qvalues = np.interp(scores, np.flip(target_scores), np.flip(target_qvalues))
     return qvalues
 
 
@@ -354,9 +355,7 @@ def qvalues_from_counts(
         * ((~targets_sorted).cumsum() + 1)
         / np.maximum(targets_sorted.cumsum(), 1)
     )
-    qvalues_sorted = monotonize_simple(
-        fdr_sorted, ascending=True, reverse=True
-    )
+    qvalues_sorted = monotonize_simple(fdr_sorted, ascending=True, reverse=True)
 
     # Extract unique scores and take qvalue from the last of them
     scores_uniq, idx_uniq, rev_uniq, cnt_uniq = np.unique(
@@ -411,9 +410,7 @@ def qvalues_func_from_hist(
 
     fdr_flipped = factor * (decoys_sum + 1) / np.maximum(targets_sum, 1)
     fdr_flipped = np.clip(fdr_flipped, 0.0, 1.0)
-    qvalues_flipped = monotonize_simple(
-        fdr_flipped, ascending=True, reverse=True
-    )
+    qvalues_flipped = monotonize_simple(fdr_flipped, ascending=True, reverse=True)
     qvalues = np.flip(qvalues_flipped)
 
     # We need to append zero to end of the qvalues for right edge of the last

--- a/mokapot/typecheck.py
+++ b/mokapot/typecheck.py
@@ -17,7 +17,7 @@ def check_dtype(act_dtype, req_type):
     elif isinstance(req_type, type(Any)):
         return True
     else:
-        return act_dtype == req_type
+        return np.issubdtype(act_dtype, req_type)
 
 
 def check_numpy_ndarray(

--- a/mokapot/typecheck.py
+++ b/mokapot/typecheck.py
@@ -1,0 +1,72 @@
+from inspect import isclass
+from types import UnionType
+from typing import Any, get_args
+
+import numpy as np
+from typeguard import (
+    checker_lookup_functions,
+    TypeCheckerCallable,
+    TypeCheckError,
+    TypeCheckMemo,
+)
+
+
+def check_dtype(act_dtype, req_type):
+    if isinstance(req_type, UnionType):
+        return any([check_dtype(act_dtype, t) for t in get_args(req_type)])
+    elif isinstance(req_type, type(Any)):
+        return True
+    else:
+        return act_dtype == req_type
+
+
+def check_numpy_ndarray(
+    value: Any, origin_type: Any, args: tuple[Any, ...], memo: TypeCheckMemo
+) -> None:
+    if not isinstance(value, np.ndarray):
+        raise TypeCheckError(f"is no numpy.ndarray[{args}].")
+
+    for arg in args:
+        base_msg = f"is an ndarray[{value.dtype}, {value.shape}]"
+        if isinstance(arg, type | UnionType | type(Any)):
+            if not check_dtype(value.dtype, arg):
+                raise TypeCheckError(
+                    f"{base_msg} and not numpy.ndarray[{args}] (type mismatch)"
+                )
+        elif isinstance(arg, int | tuple):
+            if isinstance(arg, int):
+                arg = (arg,)
+            if len(arg) != len(value.shape):
+                raise TypeCheckError(
+                    f"{base_msg} and not numpy.ndarray[{args}] (dimension mismatch)"
+                )
+            okay = [s == t for s, t in zip(arg, value.shape) if s != -1]
+            if not all(okay):
+                raise TypeCheckError(
+                    f"{base_msg} and not numpy.ndarray[{args}] (shape mismatch)"
+                )
+        else:
+            raise TypeCheckError(
+                f"{base_msg}. Unkonwn argument type: {type(arg)} {arg}"
+            )
+
+
+def numpy_ndarray_checker_lookup(
+    origin_type: Any, args: tuple[Any, ...], extras: tuple[Any, ...]
+) -> TypeCheckerCallable | None:
+    if isclass(origin_type) and issubclass(origin_type, np.ndarray):
+        return check_numpy_ndarray
+
+    return None
+
+
+def register_numpy_typechecker():
+    if numpy_ndarray_checker_lookup not in checker_lookup_functions:
+        checker_lookup_functions.append(numpy_ndarray_checker_lookup)
+
+
+def unregister_numpy_typechecker():
+    try:
+        checker_lookup_functions.remove(numpy_ndarray_checker_lookup)
+    except ValueError:
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from triqler.qvality import getQvaluesFromScores
 
 from mokapot import LinearPsmDataset, OnDiskPsmDataset
 from mokapot.qvalues import tdc
+from mokapot.typecheck import register_numpy_typechecker
 from mokapot.utils import convert_targets_column
 
 
@@ -666,3 +667,6 @@ def pytest_plugin_registered(plugin, manager):
     if str(plugin).find("xdist.dsession.DSession") != -1:
         if debugger_active:
             manager.unregister(plugin)
+
+
+register_numpy_typechecker()

--- a/tests/unit_tests/test_peps.py
+++ b/tests/unit_tests/test_peps.py
@@ -60,7 +60,7 @@ def test_monotonize_simple():
 
 
 def test_monotonize():
-    x = np.array([2, 3, 1])
+    x = np.array([2, 3, 1], dtype=float)
     w = np.array([2, 1, 10])
     y = peps.monotonize_nnls(x, w, False)
     testing.assert_allclose(y, np.array([7 / 3, 7 / 3, 1]))
@@ -79,28 +79,26 @@ def test_monotonize():
 
     # Test to check simple_averaging parameter when set to True
     assert np.allclose(
-        peps.monotonize(np.array([1, 2, 5, 4, 3]), True, True),
+        peps.monotonize(np.array([1.0, 2, 5, 4, 3]), True, True),
         np.array([1, 2, 4, 4, 4]),
     )
     assert np.allclose(
-        peps.monotonize(np.array([1, 2, 6, 6, 3]), True, True),
+        peps.monotonize(np.array([1.0, 2, 6, 6, 3]), True, True),
         np.array([1, 2, 4.5, 4.5, 4.5]),
     )
 
     # Test to check simple_averaging parameter when set to False
     assert np.allclose(
-        peps.monotonize(np.array([1, 2, 5, 4, 3]), True, False),
+        peps.monotonize(np.array([1.0, 2, 5, 4, 3]), True, False),
         np.array([1, 2, 4, 4, 4]),
     )
     assert np.allclose(
-        peps.monotonize(np.array([1, 2, 6, 6, 3]), True, False),
+        peps.monotonize(np.array([1.0, 2, 6, 6, 3]), True, False),
         np.array([1, 2, 5, 5, 5]),
     )
 
 
 def test_fit_nnls0():
-    # n = np.array([3, 2, 0, 0, 1, 1, 3])
-    # k = np.array([0, 0, 1, 1, 1, 1, 3])
     n = np.array([0, 2, 1, 0, 1, 0, 2, 0])
     k = np.array([1, 0, 0, 1, 1, 1, 2, 1])
     p_asc = np.array([0, 0, 0, 1 / 2, 1, 1, 1, 1])
@@ -208,18 +206,14 @@ def test_peps_qvality(is_tdc):
 
 @pytest.mark.parametrize("is_tdc", [True, False])
 def test_peps_kde_nnls(is_tdc):
-    np.random.seed(
-        1253
-    )  # this produced an error with failing iterations in nnls
+    np.random.seed(1253)  # this produced an error with failing iterations in nnls
     scores, targets = get_target_decoy_data()
     peps_values = peps.peps_from_scores_kde_nnls(scores, targets, is_tdc)
     assert np.all(peps_values >= 0)
     assert np.all(peps_values <= 1)
     assert np.all(np.diff(peps_values) * np.diff(scores) <= 0)
 
-    np.random.seed(
-        1245
-    )  # this produced an assertion error due to peps over 1.0
+    np.random.seed(1245)  # this produced an assertion error due to peps over 1.0
     scores, targets = get_target_decoy_data()
     peps_values = peps.peps_from_scores_kde_nnls(scores, targets, is_tdc)
     assert np.all(peps_values >= 0)
@@ -254,9 +248,7 @@ def test_hist_data_from_iterator():
             yield scores[i : i + chunksize], targets[i : i + chunksize]
 
     bins = np.histogram_bin_edges(scores, bins=31)
-    e0, t0, d0 = peps.hist_data_from_scores(
-        scores, targets, bins=bins
-    ).as_counts()
+    e0, t0, d0 = peps.hist_data_from_scores(scores, targets, bins=bins).as_counts()
     e1, t1, d1 = peps.hist_data_from_iterator(
         score_iterator(scores, targets), bin_edges=bins
     ).as_counts()
@@ -265,9 +257,7 @@ def test_hist_data_from_iterator():
     assert d0 == approx(d1)
 
     bins = np.histogram_bin_edges(scores, bins=17)
-    e0, t0, d0 = peps.hist_data_from_scores(
-        scores, targets, bins=bins
-    ).as_densities()
+    e0, t0, d0 = peps.hist_data_from_scores(scores, targets, bins=bins).as_densities()
     e1, t1, d1 = peps.hist_data_from_iterator(
         score_iterator(scores, targets, chunksize=7), bin_edges=bins
     ).as_densities()
@@ -282,13 +272,9 @@ def test_peps_from_qvality_sorting():
 
     N = 1126
     targets = (rng.uniform(0, 1, N)) > 0.7
-    scores = targets * rng.normal(1, 1, N) + (1 - targets) * rng.normal(
-        -1, 1, N
-    )
+    scores = targets * rng.normal(1, 1, N) + (1 - targets) * rng.normal(-1, 1, N)
 
-    peps0 = peps.peps_from_scores_qvality(
-        scores, targets, True, use_binary=False
-    )
+    peps0 = peps.peps_from_scores_qvality(scores, targets, True, use_binary=False)
 
     index = np.argsort(scores)[::-1]
     scores_sorted, targets_sorted = scores[index], targets[index]

--- a/tests/unit_tests/test_qvalues.py
+++ b/tests/unit_tests/test_qvalues.py
@@ -2,16 +2,16 @@
 These tests verify that our q-value calculations are correct.
 """
 
-import pytest
 import numpy as np
-from mokapot.peps import TDHistData, hist_data_from_scores
+import pytest
 from scipy import stats
 
+from mokapot.peps import hist_data_from_scores, TDHistData
 from mokapot.qvalues import (
-    tdc,
-    qvalues_from_peps,
     qvalues_from_counts,
+    qvalues_from_peps,
     qvalues_func_from_hist,
+    tdc,
 )
 
 
@@ -38,7 +38,7 @@ def desc_scores():
         1,
         1,
     ])
-    return scores, target, qvals
+    return scores.astype(float), target == 1, qvals.astype(float)
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def asc_scores():
         1,
         1,
     ])
-    return scores, target, qvals
+    return scores.astype(float), target == 1, qvals.astype(float)
 
 
 @pytest.mark.parametrize("dtype", [np.float64, np.uint8, np.int8, np.float32])
@@ -94,18 +94,6 @@ def test_tdc_ascending(asc_scores, dtype):
 
     qvals = tdc(scores, target.astype(dtype), desc=False)
     np.testing.assert_allclose(qvals, true_qvals, atol=1e-7)
-
-
-def test_tdc_non_bool():
-    """If targets is not boolean, should get a value error"""
-    scores = np.array([1, 2, 3, 4, 5])
-    targets = np.array(["1", "0", "1", "0", "blarg"])
-    with pytest.raises(ValueError):
-        # Q-June 2024: JSP Since this function is runtime-type-checked,
-        # what is the purpose of this test?
-        # should it be raise if the passed type is not
-        # bool or if it is not convertible to bool?
-        tdc(scores, targets)
 
 
 def test_tdc_diff_len():

--- a/tests/unit_tests/test_typecheck.py
+++ b/tests/unit_tests/test_typecheck.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+import numpy as np
+from pytest import raises
+from typeguard import typechecked, TypeCheckError
+
+
+def test_typecheck():
+    # Without arguments
+    @typechecked
+    def f1(x: np.ndarray):
+        return x
+
+    f1(np.array([1, 2, 3]))
+    f1(np.array(["1", "2", "3"]))
+    raises(TypeCheckError, f1, [1, 2, 3])
+
+    # With basic dtype argument
+    @typechecked
+    def f2(x: np.ndarray[float]):
+        return x
+
+    f2(np.array([1.0, 2.0, 3.0]))
+    f2(np.zeros(shape=(3, 5), dtype=float))
+    raises(TypeCheckError, f2, np.ones(shape=(2, 3, 4), dtype=int))
+    raises(TypeCheckError, f2, [1, 2, 3])
+    raises(TypeCheckError, f2, np.array([1, 2, 3]))
+    raises(TypeCheckError, f2, np.array(["1", "2", "3"]))
+
+    @typechecked
+    def f3(x: np.ndarray[int]):
+        return x
+
+    f3(np.array([1, 2, 3]))
+    raises(TypeCheckError, f3, np.array([1.0, 2.0, 3.0]))
+
+    # Union dtype
+    @typechecked
+    def f4(x: np.ndarray[int | float]):
+        return x
+
+    f4(np.array([1.0, 2.0, 3.0]))
+    f4(np.array([1, 2, 3]))
+    raises(TypeCheckError, f4, np.array(["1", "2", "3"]))
+
+    @typechecked
+    def f5(x: np.ndarray[int] | np.ndarray[float]):
+        return x
+
+    f5(np.array([1.0, 2.0, 3.0]))
+    f5(np.array([1, 2, 3]))
+    raises(TypeCheckError, f5, np.array(["1", "2", "3"]))
+
+    # Check with shape
+    @typechecked
+    def f6(x: np.ndarray[(2, 3), float]):
+        return x
+
+    f6(np.zeros(shape=(2, 3), dtype=float))
+    raises(TypeCheckError, f6, np.array([1.0, 2.0, 3.0]))
+    raises(TypeCheckError, f6, np.zeros(shape=(2, 3), dtype=int))
+    raises(TypeCheckError, f6, np.zeros(shape=(2, 3, 1), dtype=float))
+    raises(TypeCheckError, f6, np.zeros(shape=(2, 4), dtype=float))
+    raises(TypeCheckError, f6, np.zeros(shape=(3, 3), dtype=float))
+
+    @typechecked
+    def f7(x: np.ndarray[int, (-1,)]):
+        return x
+
+    f7(np.ones(shape=10, dtype=int))
+    raises(TypeCheckError, f7, np.ones(shape=10, dtype=float))
+    raises(TypeCheckError, f7, np.ones(shape=(2, 5), dtype=float))
+
+    @typechecked
+    def f8(x: np.ndarray[Any, (3, -1, 5)]):
+        return x
+
+    f8(np.ones(shape=(3, 1, 5)))
+    f8(np.ones(shape=(3, 2, 5)))
+    raises(TypeCheckError, f8, np.ones(shape=(3, 1, 5, 1)))
+    raises(TypeCheckError, f8, np.ones(shape=(3, 1, 4)))
+    raises(TypeCheckError, f8, np.ones(shape=(2, 1, 4)))


### PR DESCRIPTION
Some really tricky errors slipped through, because numpy arrays weren't correcly checked for their dtype. In constrast to lists where [1,2,3] would fail for list[float], npndarray([1,2,3]) would have passed for np.ndarray[float]. This PR fixes that, plus also adds the ability to check shapes.
